### PR TITLE
don't run python_pip on amazon linux

### DIFF
--- a/recipes/helper.rb
+++ b/recipes/helper.rb
@@ -150,13 +150,15 @@ def get_debian_os_name
 end
 
 def pip_python_module(module_name, module_version)
-  python_pip module_name do
-    version module_version
-  end
-  # amazon requires special handling
-  execute 'pip-python install' do
-    command ['pip-python', 'install', module_name + "==" + module_version] 
-    action :run
-    only_if { node['platform'] == 'amazon' }
+  if node['platform'] == 'amazon'
+    # amazon requires special handling
+    execute 'pip-python install' do
+      command ['pip-python', 'install', module_name + "==" + module_version]
+      action :run
+    end
+  else
+    python_pip module_name do
+      version module_version
+    end
   end
 end


### PR DESCRIPTION
This was still running python_pip method on amazon linux which was failing.  This prevents that method from being used with amazon linux.