### PR TITLE
Adds configuration to the protocol plugin.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,3 +15,14 @@ default['SignalFx']['collectd']['logfile']['PrintSeverity'] = false
 # set this to true to enable the dogstatsd compatible statsd listener
 default['SignalFx']['collectd']['enable_statsd'] = false
 default['SignalFx']['collectd']['statsd_port'] = 8125
+
+default['SignalFx']['collectd']['protocols']['values'] = [
+  "Icmp:InDestUnreachs",
+  "Tcp:CurrEstab",
+  "Tcp:OutSegs",
+  "Tcp:RetransSegs",
+  "TcpExt:DelayedACKs",
+  "TcpExt:DelayedACKs",
+  "/Tcp:.*Opens/",
+  "/^TcpExt:.*Octets/",
+]

--- a/templates/default/collectd-rhel.conf.erb
+++ b/templates/default/collectd-rhel.conf.erb
@@ -70,15 +70,9 @@ LoadPlugin load
 LoadPlugin memory
 LoadPlugin protocols
 <Plugin "protocols">
-  Value "Icmp:InDestUnreachs"
-  Value "Tcp:CurrEstab"
-  Value "Tcp:OutSegs"
-  Value "Tcp:RetransSegs"
-  Value "TcpExt:DelayedACKs"
-  Value "TcpExt:DelayedACKs"
-
-  Value "/Tcp:.*Opens/"
-  Value "/^TcpExt:.*Octets/"
+<% node['SignalFx']['collectd']['protocols']['values'].each do |value| -%>
+  Value "<%= value %>"
+<% end %>
   IgnoreSelected false
 </Plugin>
 

--- a/templates/default/collectd.conf.erb
+++ b/templates/default/collectd.conf.erb
@@ -70,15 +70,9 @@ LoadPlugin load
 LoadPlugin memory
 LoadPlugin protocols
 <Plugin "protocols">
-  Value "Icmp:InDestUnreachs"
-  Value "Tcp:CurrEstab"
-  Value "Tcp:OutSegs"
-  Value "Tcp:RetransSegs"
-  Value "TcpExt:DelayedACKs"
-  Value "TcpExt:DelayedACKs"
-
-  Value "/Tcp:.*Opens/"
-  Value "/^TcpExt:.*Octets/"
+<% node['SignalFx']['collectd']['protocols']['values'].each do |value| -%>
+  Value "<%= value %>"
+<% end %>
   IgnoreSelected false
 </Plugin>
 


### PR DESCRIPTION
I needed to add some values to the protocol plugins configuration, which isn't possible currently.

This PR allowed me to do the following in my wrapper recipe:

```ruby
  node.default['SignalFx']['collectd']['protocols']['values'] += [
    "Udp:InDatagrams",
    "Udp:InErrors",
    "Udp:OutDatagrams",
    "Udp:RcvbufErrors",
  ]
```