### PR TITLE
Flush package cache before installing collectd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.2.4
+* Fix collectd installation on Centos-based boxes by flushing cache before install.
+
 ## v0.2.3
 * add support for amazon linux 2016.09
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ issues_url 'https://github.com/signalfx/chef_install_configure_collectd/issues'
 license 'Copyright SignalFx, Inc. All rights reserved'
 description 'Use this cookbook to install the SignalFx collectd agent and collectd plugins.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.2.3'
+version '0.2.4'
 
 supports "centos"
 supports "amazon"

--- a/recipes/helper.rb
+++ b/recipes/helper.rb
@@ -115,6 +115,10 @@ def install_package(package_name)
       version node['collectd_version']
       action :install
     end
+  elsif node['platform'] == 'centos' or node['platform'] == 'amazon'
+    yum_package package_name do
+      flush_cache( {:before=>true, :after=>false})
+    end
   else
     package package_name
   end  


### PR DESCRIPTION
The collectd package install was failing as yum
couldn't find the package. This flushes Chef's
in-memory metadata cache before trying to install
collectd since the RPM package was added since the
start of the Chef run.