### PR TITLE
Adds arbitrary config support to ES plugin.

### DIFF
--- a/attributes/elasticsearch_plugin.rb
+++ b/attributes/elasticsearch_plugin.rb
@@ -1,3 +1,4 @@
 default['elasticsearch']['clustername'] = 'elasticsearch'
 default['elasticsearch']['indexes'] = '_all'
 default['elasticsearch']['python_folder'] = '/usr/share/collectd/python/'
+default['elasticsearch']['config'] = {}

--- a/recipes/config-elasticsearch.rb
+++ b/recipes/config-elasticsearch.rb
@@ -26,7 +26,8 @@ template "#{node['collectd_managed_conf_folder']}/10-elasticsearch.conf" do
   variables({
     :clustername => node['elasticsearch']['clustername'],
     :indexes => node['elasticsearch']['indexes'],
-    :python_folder => node['elasticsearch']['python_folder']
+    :python_folder => node['elasticsearch']['python_folder'],
+    :config => node['elasticsearch']['config'],
   })
   notifies :restart, 'service[collectd]'
 end

--- a/templates/default/10-elasticsearch.conf.erb
+++ b/templates/default/10-elasticsearch.conf.erb
@@ -13,5 +13,8 @@
         Indexes ["<%= @indexes %>"]
         EnableIndexStats true
         EnableClusterHealth true
+        <% @config.each do |key, value| -%>
+        <%= key %> <%= value %>
+        <% end -%>
     </Module>
 </Plugin>


### PR DESCRIPTION
The elasticsearch plugin has many configuration options that can't be set using this cookbook. In the interest of not coupling the recipe to the plugin, this PR adds support for any key value pair.