### PR TITLE
RHEL 6/7 Support

### DIFF
--- a/attributes/SignalFx_repo.rb
+++ b/attributes/SignalFx_repo.rb
@@ -10,7 +10,7 @@
 #   - The ubuntu ppa link
 #
 #   Sopport operation system 
-#   - centos: 6.*, 7.* 
+#   - RHEL/centos: 6.*, 7.* 
 #   - amazon Linux: 2014.09, 2015.03, 2015.09, 2016.03, 2016.09
 #   - ubuntu : 12.04 (precise), 14.04 (trusty), 15.04 (vivid)
 #  
@@ -25,6 +25,16 @@ default['SignalFx_rpm_repo']['centos']['6']['SignalFx-Plugin-repo'] =
   'SignalFx-collectd_plugin-RPMs-centos-release-latest.noarch.rpm'
 default['SignalFx_rpm_repo']['centos']['7']['SignalFx-Plugin-repo'] =
   'SignalFx-collectd_plugin-RPMs-centos-release-latest.noarch.rpm'
+
+# RHEL uses the same repos as Centos
+default['SignalFx_rpm_repo']['rhel']['6']['SignalFx-repo'] =
+  default['SignalFx_rpm_repo']['centos']['6']['SignalFx-repo']
+default['SignalFx_rpm_repo']['rhel']['7']['SignalFx-repo'] =
+  default['SignalFx_rpm_repo']['centos']['7']['SignalFx-repo']
+default['SignalFx_rpm_repo']['rhel']['6']['SignalFx-Plugin-repo'] =
+  default['SignalFx_rpm_repo']['centos']['6']['SignalFx-Plugin-repo']
+default['SignalFx_rpm_repo']['rhel']['7']['SignalFx-Plugin-repo'] =
+  default['SignalFx_rpm_repo']['centos']['7']['SignalFx-Plugin-repo']
 
 # repo rpms for amazon linux
 default['SignalFx_rpm_repo']['amazon']['2014.09']['SignalFx-repo'] =

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,12 +6,12 @@ issues_url 'https://github.com/signalfx/chef_install_configure_collectd/issues'
 license 'Copyright SignalFx, Inc. All rights reserved'
 description 'Use this cookbook to install the SignalFx collectd agent and collectd plugins.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.2.5'
+version '0.3.0'
 
 supports "centos"
 supports "amazon"
 supports "ubuntu"
 supports "debian"
 
-depends 'apt', '> 2.8'
-depends 'python', '> 1.4'
+depends 'apt', '< 6.0'
+depends 'poise-python', '~> 1.6.0'

--- a/recipes/config-docker.rb
+++ b/recipes/config-docker.rb
@@ -10,7 +10,7 @@
 require File.expand_path("../helper.rb", __FILE__)
 
 include_recipe 'chef_install_configure_collectd::default'
-install_package_on_redhat 'epel-release'
+epel_release_for_redhat
 install_python_pip
 
 pip_python_module("py-dateutil", "2.2")

--- a/recipes/config-iostat.rb
+++ b/recipes/config-iostat.rb
@@ -10,7 +10,7 @@
 require File.expand_path("../helper.rb", __FILE__)
 
 include_recipe 'chef_install_configure_collectd::default'
-install_package_on_redhat 'epel-release'
+epel_release_for_redhat
 package "sysstat"
 
 directory node['iostat']['python_folder'] do

--- a/recipes/config-vmstat.rb
+++ b/recipes/config-vmstat.rb
@@ -10,7 +10,7 @@
 require File.expand_path("../helper.rb", __FILE__)
 
 include_recipe 'chef_install_configure_collectd::default'
-install_package_on_redhat 'epel-release'
+epel_release_for_redhat
 package "procps"
 
 directory node['vmstat']['python_folder'] do

--- a/recipes/install-collectd.rb
+++ b/recipes/install-collectd.rb
@@ -106,6 +106,9 @@ end
 
 SignalFx_Repo_Link = node['SignalFx_rpm_repo']['uri']
 case node['platform']
+when 'redhat'
+  # Get the rhel integer version
+  install_in_redhat('rhel', node['platform_version'].to_i.to_s)
 when 'centos'
   # Get the centos integer version
   install_in_redhat('centos', node['platform_version'].to_i.to_s)

--- a/templates/default/10-write_http-plugin.conf.erb
+++ b/templates/default/10-write_http-plugin.conf.erb
@@ -1,8 +1,10 @@
 LoadPlugin write_http
 <Plugin "write_http">
-  <URL "<%= @INGEST_HOST %>">
+  <Node "SignalFx">
+    URL "<%= @INGEST_HOST %>"
     User "auth"
     Password "<%= @API_TOKEN %>"
     Format "JSON"
-  </URL>
+    LogHttpError true
+  </Node>
 </Plugin>


### PR DESCRIPTION
This requires some different steps from other RH distros, such as manually
installing the epel-release package instead of using yum

It uses the same collectd rpm that centos uses.

Updating config structure for write_http to reflect latest version of collectd